### PR TITLE
feat: add About links

### DIFF
--- a/app/components/About/index.tsx
+++ b/app/components/About/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import * as S from "./styles";
+
+export const About = () => (
+  <S.Container>
+    <a href="https://github.com/howmuchgreen/website" target="_blank">
+      GitHub
+    </a>{" "}
+    /{" "}
+    <a href="https://twitter.com/howmuchgreen" target="_blank">
+      Twitter
+    </a>
+  </S.Container>
+);

--- a/app/components/About/styles.ts
+++ b/app/components/About/styles.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  position: fixed;
+  bottom: 0px;
+  right: 0px;
+  padding: 8px;
+  opacity: 0.5;
+  transition: 0.3s opacity;
+
+  :hover {
+    opacity: 1;
+  }
+
+  a {
+    color: inherit;
+
+    :hover {
+      text-decoration: underline;
+    }
+  }
+`;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,6 +6,7 @@ import {
   Scripts,
   ScrollRestoration,
 } from "remix";
+import { About } from "./components/About";
 import styles from "./styles/global.css";
 
 export function links() {
@@ -42,6 +43,7 @@ export default function App() {
       </head>
       <body>
         <Outlet />
+        <About />
         <ScrollRestoration />
         <Scripts />
         {process.env.NODE_ENV === "development" && <LiveReload />}


### PR DESCRIPTION
This PR adds a link to Github and to Twitter:
<img width="1153" alt="CleanShot 2022-02-05 at 22 35 29@2x" src="https://user-images.githubusercontent.com/906276/152659802-1afad3f1-fb07-4e87-adb8-c612c7494e34.png">

Note: this wasn't working with NextJS (because I don't know, NextJS cannot precompile the styled-components for components in the `_document` template file #NextJS quoi)